### PR TITLE
Docs&refactor/clamp refactor

### DIFF
--- a/src/com/stuypulse/stuylib/math/SLMath.java
+++ b/src/com/stuypulse/stuylib/math/SLMath.java
@@ -24,10 +24,10 @@ public final class SLMath {
      * Clamps a value to the inclusive range defined by {@code min} and {@code max}.
      * The order of {@code min} and {@code max} does not matter.
      *
-     * @param x the value to clamp
+     * @param x input
      * @param min one bound of the range
      * @param max the other bound of the range
-     * @return {@code x} clamped to the specified range
+     * @return clamped input
      */
     public static double clamp(double x, double min, double max) {
         double lower = Math.min(min, max);
@@ -36,7 +36,7 @@ public final class SLMath {
         if (x < lower) return lower;
         if (x > upper) return upper;
         return x;
-}
+    }
 
     /**
      * clamp input from max to -max

--- a/src/com/stuypulse/stuylib/math/SLMath.java
+++ b/src/com/stuypulse/stuylib/math/SLMath.java
@@ -21,7 +21,7 @@ public final class SLMath {
     /**************/
 
     /**
-     * Clamps a value to the inclusive range defined by {@code min} and {@code max}.
+     * Clamps input to the range defined by {@code min} and {@code max}.
      * The order of {@code min} and {@code max} does not matter.
      *
      * @param x input

--- a/src/com/stuypulse/stuylib/math/SLMath.java
+++ b/src/com/stuypulse/stuylib/math/SLMath.java
@@ -21,23 +21,22 @@ public final class SLMath {
     /**************/
 
     /**
-     * clamp input from max to min
+     * Clamps a value to the inclusive range defined by {@code min} and {@code max}.
+     * The order of {@code min} and {@code max} does not matter.
      *
-     * @param x input
-     * @param min min value for x
-     * @param max max value for x
-     * @return clamp input
+     * @param x the value to clamp
+     * @param min one bound of the range
+     * @param max the other bound of the range
+     * @return {@code x} clamped to the specified range
      */
     public static double clamp(double x, double min, double max) {
-        if (min < max) {
-            if (x > max) return max;
-            if (x < min) return min;
-        } else {
-            if (x > min) return min;
-            if (x < max) return max;
-        }
+        double lower = Math.min(min, max);
+        double upper = Math.max(min, max);
+    
+        if (x < lower) return lower;
+        if (x > upper) return upper;
         return x;
-    }
+}
 
     /**
      * clamp input from max to -max


### PR DESCRIPTION
I made a few messy commits and if this gets merged, I think that it should be squashed as well.

I noticed in SLMath.clamp() the min and max values were interchangeable, so I replaced the if else (which I thought was less readable) with getting doubles lower and upper defined by Math.min and Math.max of the two bounds passed to the function. It then compares lower and upper with {@code x}.
I'm not sure if this will have a performance impact but I suggest this change to make the code more readable.

I also changed the javadoc above the function a little: First of all, I replaced "max to min" to "the range defined by {@code min} and {@code max}".  I also noted that the order doesn't matter.
I also reflected this interchangeability in the description for arguments {@code.min} and {@code.max}.